### PR TITLE
Allow explicit control over whether or not we should skip pdbstr invocation.

### DIFF
--- a/Build/SourceLink.Build.targets
+++ b/Build/SourceLink.Build.targets
@@ -3,11 +3,11 @@
   <UsingTask TaskName="SourceLink.SourceLinkTask" AssemblyFile="SourceLink.Build.dll" />
 
   <PropertyGroup>
-    <CompileDependsOn>SourceLink;$(CompileDependsOn)</CompileDependsOn>
+    <BuildDependsOn>$(BuildDependsOn);SourceLink</BuildDependsOn>
   </PropertyGroup>
-  
+
   <Target Name="SourceLink" Condition="$(SourceLink) != ''">
-    <SourceLink.SourceLinkTask Url="$(SourceLinkUrl)" ProjectDirectory="$(MSBuildProjectDirectory)" Sources="@(Compile)" TargetPath="$(TargetPath)" />
+    <SourceLink.SourceLinkTask Url="$(SourceLinkUrl)" ProjectDirectory="$(MSBuildProjectDirectory)" Sources="@(Compile)" TargetPath="$(TargetPath)" SkipPdbstr="$(SourceLinkSkipPdbstr)"/>
   </Target>
 
 </Project>

--- a/Build/SourceLinkTask.fs
+++ b/Build/SourceLinkTask.fs
@@ -14,6 +14,8 @@ type SourceLinkTask() =
 
     member val Url = String.Empty with set, get
 
+    member val SkipPdbstr = "false" with set, get
+
     [<Required>]
     member val ProjectDirectory = String.Empty with set, get
 
@@ -35,7 +37,8 @@ type SourceLinkTask() =
             let args =
                 [
                     yield IndexArgs.Not_Verify_Pdb
-                    yield IndexArgs.Not_Pdbstr
+                    if String.Compare("true", x.SkipPdbstr, StringComparison.OrdinalIgnoreCase) = 0 then
+                        yield IndexArgs.Not_Pdbstr
                     yield IndexArgs.Pdb (Path.ChangeExtension(x.TargetPath, ".pdb"))
                     yield IndexArgs.Url x.Url
                     for source in x.Sources do
@@ -45,15 +48,11 @@ type SourceLinkTask() =
             
             let exe = Path.combine (System.Reflection.Assembly.GetExecutingAssembly().Location |> Path.GetDirectoryName) "SourceLink.exe"
 
-            let psSpecialChars = [| '%' |] // PowerShell special characters
-            let psNeedsQuotes (s: string) = s.IndexOfAny psSpecialChars <> -1
             let arguments =
                 let sb = StringBuilder()
                 sb.Appendf "index"
                 for arg in args do
-                    if psNeedsQuotes arg then
-                        sb.Appendf " '%s'" arg
-                    else sb.Appendf " %s" arg
+                    sb.Appendf " %s" arg
                 sb.ToString()
 
             let p = Process()


### PR DESCRIPTION
1) We ensure that SourceLink runs after build, rather than precompile.
2) We allow the project file to explicitly control the value of Not_Pdbstr.
3) Unrelated, we found that urls were being double quoted (at least in our environment) and that the url needed to be passed in raw from the build environment. (Otherwise the Uri fails to parse since it's wrapped with an extra set of single quotes).
